### PR TITLE
chore(security): bump concurrent-ruby 1.3.6 → 1.3.7 (Dependabot #14,15,16)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    noun-project-api (4.0.3)
+    noun-project-api (4.0.4)
       activesupport
       oauth (~> 1.1)
 
@@ -24,7 +24,7 @@ GEM
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.0.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     diff-lcs (1.5.0)
     drb (2.2.3)
@@ -95,4 +95,4 @@ DEPENDENCIES
   rubocop (~> 1)
 
 BUNDLED WITH
-   2.4.10
+   2.4.6

--- a/noun-project-api.gemspec
+++ b/noun-project-api.gemspec
@@ -6,7 +6,7 @@ require "date"
 
 Gem::Specification.new do |s|
   s.name        = "noun-project-api"
-  s.version     = "4.0.3"
+  s.version     = "4.0.4"
   s.platform    = Gem::Platform::RUBY
   s.date        = Date.today.to_s
   s.summary     = "An API wrapper for The Noun Project API's"


### PR DESCRIPTION
## Summary
- Bumps `concurrent-ruby` from 1.3.6 to 1.3.7 to resolve Dependabot alerts #14, #15, and #16
- Patches gemspec version 4.0.3 → 4.0.4 so consuming services pick up the updated transitive dependency

## Changes
- `concurrent-ruby` 1.3.6 → 1.3.7
- `noun-project-api` gemspec version 4.0.3 → 4.0.4

## Test plan
- [ ] CI passes